### PR TITLE
Setup dotfile storage consistently fixes #10

### DIFF
--- a/cli/checkout.go
+++ b/cli/checkout.go
@@ -8,19 +8,24 @@ import (
 )
 
 type checkoutCommand struct {
-	storage    *file.Storage
+	getStorage func() (*file.Storage, error)
 	fileName   string
 	commitHash string
 }
 
 func (c *checkoutCommand) run(ctx *kingpin.ParseContext) error {
+	_, err := c.getStorage()
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("TODO: Checkout %#v commitHash: %#v\n", c.fileName, c.commitHash)
 	return nil
 }
 
-func addCheckoutSubCommandToApplication(app *kingpin.Application, storage *file.Storage) {
+func addCheckoutSubCommandToApplication(app *kingpin.Application, gs func() (*file.Storage, error)) {
 	cc := &checkoutCommand{
-		storage: storage,
+		getStorage: gs,
 	}
 	c := app.Command("checkout", "revert a file to a previously committed state").Action(cc.run)
 	c.Arg("file-name", "file to revert changes in").Required().StringVar(&cc.fileName)

--- a/cli/commit_test.go
+++ b/cli/commit_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommit(t *testing.T) {
+	clearTestStorage()
+	initTestFile(t)
+
+	commitCommand := &commitCommand{
+		getStorage:    getTestStorageClosure(),
+		commitMessage: "test commit",
+	}
+
+	t.Run("returns error when file is not tracked", func(t *testing.T) {
+		commitCommand.fileName = notTrackedFile
+		assert.Error(t, commitCommand.run(nil))
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		commitCommand.fileName = trackedFileAlias
+		assert.NoError(t, commitCommand.run(nil))
+	})
+}

--- a/cli/diff.go
+++ b/cli/diff.go
@@ -8,18 +8,23 @@ import (
 )
 
 type diffCommand struct {
-	storage  *file.Storage
-	fileName string
+	getStorage func() (*file.Storage, error)
+	fileName   string
 }
 
 func (d *diffCommand) run(ctx *kingpin.ParseContext) error {
+	_, err := d.getStorage()
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("TODO: Diff %#v\n", d.fileName)
 	return nil
 }
 
-func addDiffSubCommandToApplication(app *kingpin.Application, storage *file.Storage) {
+func addDiffSubCommandToApplication(app *kingpin.Application, gs func() (*file.Storage, error)) {
 	dc := &diffCommand{
-		storage: storage,
+		getStorage: gs,
 	}
 	c := app.Command("diff", "check changes to tracked file").Action(dc.run)
 	c.Arg("file-name", "file to check changes in").Required().StringVar(&dc.fileName)

--- a/cli/edit_test.go
+++ b/cli/edit_test.go
@@ -33,8 +33,8 @@ func TestEditCommandLaunchesEditor(t *testing.T) {
 	os.Setenv("EDITOR", arbitraryEditor)
 
 	editCommand := &editCommand{
-		fileName: testAlias,
-		storage:  getTestStorage(),
+		fileName:   trackedFileAlias,
+		getStorage: getTestStorageClosure(),
 	}
 
 	clearTestStorage()
@@ -56,7 +56,7 @@ func TestErrorIfEditorNotSet(t *testing.T) {
 	os.Unsetenv("EDITOR")
 
 	command := &editCommand{
-		fileName: testAlias,
+		fileName: trackedFileAlias,
 	}
 	err := command.run(nil)
 	assert.Equal(t, ErrEditorEnvVarNotSet, err)
@@ -66,6 +66,6 @@ func TestEditHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
 	}
-	assert.Equal(t, testAlias, os.Args[1])
+	assert.Equal(t, trackedFileAlias, os.Args[1])
 	os.Exit(0)
 }

--- a/cli/helpers_test.go
+++ b/cli/helpers_test.go
@@ -10,24 +10,24 @@ import (
 )
 
 const (
-	arbitraryFile = "helpers_test.go"
-	testAlias     = "helpers_test"
-	testDir       = "testdata/"
+	nonExistantFile  = "file_does_not_exist"
+	notTrackedFile   = "/dev/null"
+	trackedFile      = "helpers_test.go"
+	trackedFileAlias = "helpers_test"
+	testDir          = "testdata/"
 )
 
-func getTestStorage() *file.Storage {
+func getTestStorageClosure() func() (*file.Storage, error) {
 	home, _ := getHome()
-	return &file.Storage{
-		Home: home,
-		Dir:  testDir,
-		Name: defaultStorageName,
-	}
+	dir := testDir
+	name := defaultStorageName
+	return getStorageClosure(home, &dir, &name)
 }
 
 func initTestFile(t *testing.T) {
 	initCommand := &initCommand{
-		fileName: arbitraryFile,
-		storage:  getTestStorage(),
+		fileName:   trackedFile,
+		getStorage: getTestStorageClosure(),
 	}
 	err := initCommand.run(nil)
 	assert.NoError(t, err)

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -6,13 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const nonExistantFile = "this does not exist"
-
 func TestInit(t *testing.T) {
 	clearTestStorage()
 
 	initCommand := &initCommand{
-		storage: getTestStorage(),
+		getStorage: getTestStorageClosure(),
 	}
 
 	t.Run("returns error when file does not exist", func(t *testing.T) {
@@ -21,7 +19,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("no error when file exists", func(t *testing.T) {
-		initCommand.fileName = arbitraryFile
+		initCommand.fileName = trackedFile
 		assert.NoError(t, initCommand.run(nil))
 	})
 }

--- a/cli/log.go
+++ b/cli/log.go
@@ -8,18 +8,23 @@ import (
 )
 
 type logCommand struct {
-	storage  *file.Storage
-	fileName string
+	getStorage func() (*file.Storage, error)
+	fileName   string
 }
 
 func (l *logCommand) run(ctx *kingpin.ParseContext) error {
+	_, err := l.getStorage()
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("TODO: Log %#v\n", l.fileName)
 	return nil
 }
 
-func addLogSubCommandToApplication(app *kingpin.Application, storage *file.Storage) {
+func addLogSubCommandToApplication(app *kingpin.Application, gs func() (*file.Storage, error)) {
 	lc := &logCommand{
-		storage: storage,
+		getStorage: gs,
 	}
 	c := app.Command("log", "shows revision history with commit hashes for a tracked file").Action(lc.run)
 	c.Arg("file-name", "tracked file to show history for").Required().StringVar(&lc.fileName)

--- a/cli/pull.go
+++ b/cli/pull.go
@@ -9,12 +9,17 @@ import (
 )
 
 type pullCommand struct {
-	storage  *file.Storage
-	fileName string
-	pullAll  bool
+	getStorage func() (*file.Storage, error)
+	fileName   string
+	pullAll    bool
 }
 
 func (pc *pullCommand) run(ctx *kingpin.ParseContext) error {
+	_, err := pc.getStorage()
+	if err != nil {
+		return err
+	}
+
 	if pc.pullAll {
 		fmt.Println("TODO: Pull all")
 	} else if pc.fileName != "" {
@@ -25,9 +30,9 @@ func (pc *pullCommand) run(ctx *kingpin.ParseContext) error {
 	return nil
 }
 
-func addPullSubCommandToApplication(app *kingpin.Application, storage *file.Storage) {
+func addPullSubCommandToApplication(app *kingpin.Application, gs func() (*file.Storage, error)) {
 	pc := &pullCommand{
-		storage: storage,
+		getStorage: gs,
 	}
 	p := app.Command("pull", "pull changes from central service").Action(pc.run)
 	p.Arg("file-name", "the file to pull").StringVar(&pc.fileName)

--- a/cli/push.go
+++ b/cli/push.go
@@ -8,18 +8,23 @@ import (
 )
 
 type pushCommand struct {
-	storage  *file.Storage
-	fileName string
+	getStorage func() (*file.Storage, error)
+	fileName   string
 }
 
 func (pc *pushCommand) run(ctx *kingpin.ParseContext) error {
+	_, err := pc.getStorage()
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("TODO: Push %#v", pc.fileName)
 	return nil
 }
 
-func addPushSubCommandToApplication(app *kingpin.Application, storage *file.Storage) {
+func addPushSubCommandToApplication(app *kingpin.Application, gs func() (*file.Storage, error)) {
 	pc := &pushCommand{
-		storage: storage,
+		getStorage: gs,
 	}
 	p := app.Command("push", "push committed changes to central service").Action(pc.run)
 	p.Arg("file-name", "the file to push").Required().StringVar(&pc.fileName)

--- a/file/files.go
+++ b/file/files.go
@@ -19,14 +19,14 @@ var pathToAliasRegex = regexp.MustCompile(`(\w+)(\.\w+)?$`)
 
 // Init sets up a file for dotfile to track.
 // Returns the alias for the newly tracked file.
-func Init(d *Storage, filePath, altName string) (string, error) {
+func Init(s *Storage, filePath, altName string) (string, error) {
 	var (
 		alias string
 		err   error
 	)
 
 	if _, err = os.Stat(filePath); os.IsNotExist(err) {
-		return "", fmt.Errorf("\"%#v\" not found", filePath)
+		return "", fmt.Errorf("%#v not found", filePath)
 	}
 
 	// Get the full path so that it can later turn it into a relative path.
@@ -43,14 +43,10 @@ func Init(d *Storage, filePath, altName string) (string, error) {
 		}
 	}
 
-	if err = d.setup(); err != nil {
-		return "", err
-	}
-
 	// Replace the full path with a relative path.
-	relativePath := strings.Replace(fullPath, d.Home, "~", 1)
+	relativePath := strings.Replace(fullPath, s.GetHome(), "~", 1)
 
-	if err = d.save(alias, &trackedFile{
+	if err = s.save(alias, &trackedFile{
 		Path: relativePath,
 	}); err != nil {
 		return "", err
@@ -59,13 +55,13 @@ func Init(d *Storage, filePath, altName string) (string, error) {
 }
 
 // Commit hashes and saves the current state of a tracked file.
-func Commit(d *Storage, alias, message string) (string, error) {
-	file, err := d.getTrackedFile(alias)
+func Commit(s *Storage, alias, message string) (string, error) {
+	file, err := s.getTrackedFile(alias)
 	if err != nil {
 		return "", err
 	}
 
-	path := file.getFullPath(d.Home)
+	path := file.getFullPath(s.GetHome())
 	f, err := os.Open(path)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to open %s", path)
@@ -93,17 +89,17 @@ func Commit(d *Storage, alias, message string) (string, error) {
 
 	file.Commits = append(file.Commits, c)
 
-	return hash, d.saveCommit(c, alias, file, compressed.Bytes())
+	return hash, s.saveCommit(c, alias, file, compressed.Bytes())
 }
 
 // GetPath gets the full path for a tracked file.
-func GetPath(d *Storage, alias string) (string, error) {
-	file, err := d.getTrackedFile(alias)
+func GetPath(s *Storage, alias string) (string, error) {
+	file, err := s.getTrackedFile(alias)
 	if err != nil {
 		return "", err
 	}
 
-	return file.getFullPath(d.Home), nil
+	return file.getFullPath(s.GetHome()), nil
 }
 
 // Creates a alias from the path of the file.

--- a/file/helpers_test.go
+++ b/file/helpers_test.go
@@ -1,0 +1,32 @@
+package file
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testFile  = "storage_test.go"
+	testAlias = "storage_test"
+	testDir   = "testdata/"
+	testName  = "files.json"
+)
+
+func clearTestStorage() {
+	os.Remove(fmt.Sprintf("%s%s", testDir, testName))
+}
+
+func getTestStorage() *Storage {
+	home, _ := os.UserHomeDir()
+	s := &Storage{}
+	s.Setup(home, testDir, testName)
+	return s
+}
+
+func initTestFile(t *testing.T, s *Storage) {
+	_, err := Init(s, testFile, testAlias)
+	assert.NoError(t, err)
+}

--- a/file/storage_test.go
+++ b/file/storage_test.go
@@ -1,0 +1,44 @@
+package file
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	s := &Storage{}
+
+	t.Run("error when home is empty", func(t *testing.T) {
+		assert.Error(t, s.Setup("", testDir, testName))
+	})
+
+	t.Run("error when dir is empty", func(t *testing.T) {
+		assert.Error(t, s.Setup("home", "", testName))
+	})
+
+	t.Run("error when name is empty", func(t *testing.T) {
+		assert.Error(t, s.Setup("home", testDir, ""))
+	})
+
+}
+
+func TestGetTrackedFile(t *testing.T) {
+	clearTestStorage()
+	s := getTestStorage()
+
+	t.Run("returns error when file is not tracked", func(t *testing.T) {
+		f, err := s.getTrackedFile(testAlias)
+		fmt.Println(err)
+		assert.Error(t, err)
+		assert.Nil(t, f)
+	})
+
+	t.Run("ok when file is tracked", func(t *testing.T) {
+		initTestFile(t, s)
+		f, err := s.getTrackedFile(testAlias)
+		assert.NoError(t, err)
+		assert.NotNil(t, f)
+	})
+}


### PR DESCRIPTION
Previously the storage struct had to be setup with
multiple calls in different places:

 - In commands.go, create a storage literal and set its fields
 - In files.go, call setup()
 - In data.go, call setPath()

There was no guarantee that the struct had been
initialized correctly. Instead I created one function, Setup(),
to do this work. The CLI must call this now.
Once Setup() is called, the backend is free to use the storage
struct.