### PR TITLE
Fix error handling that caused a nil pointer dereference

### DIFF
--- a/db/file_transaction.go
+++ b/db/file_transaction.go
@@ -130,7 +130,7 @@ func (ft *FileTransaction) InsertCommit(buff *bytes.Buffer, c *dotfile.Commit) (
 
 	newCommitID, err := insert(ft.tx, commit)
 	if err != nil {
-		return 0, errors.Wrapf(err, "inserting commit for file %d", ft.Staged.ID)
+		return 0, errors.Wrapf(err, "inserting commit %q for file %d", c.Hash, ft.FileID)
 	}
 
 	return newCommitID, nil


### PR DESCRIPTION
The problem was trying to use `ft.Staged.ID` in the err != nil
case. This was causing panics in production today. I'm still not
sure what caused the original error. At least now I'll be able to read the
error message.