### PR TITLE
Increase max commit message to 1000 from 100

### DIFF
--- a/db/commit_record.go
+++ b/db/commit_record.go
@@ -2,10 +2,13 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/knoebber/dotfile/usererror"
 	"github.com/pkg/errors"
 )
+
+const maxCommitMessageSize = 1000
 
 // CommitRecord models the commits table.
 type CommitRecord struct {
@@ -38,8 +41,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS commits_file_hash_index ON commits(file_id, ha
 func (c *CommitRecord) check(e Executor) error {
 	var count int
 
-	if err := validateStringSizes(c.Message); err != nil {
-		return err
+	if len(c.Message) > maxCommitMessageSize {
+		return usererror.Invalid(fmt.Sprintf(
+			"The maximum commit message length is %d characters", maxCommitMessageSize))
+
 	}
 
 	exists, err := hasCommit(e, c.FileID, c.Hash)

--- a/db/commit_record_test.go
+++ b/db/commit_record_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -47,5 +48,16 @@ func TestCommitsTable(t *testing.T) {
 
 		_, err := insert(Connection, c)
 		assert.Error(t, err)
+	})
+}
+
+func TestCommitRecord_check(t *testing.T) {
+	createTestDB(t)
+
+	c := new(CommitRecord)
+	c.Message = strings.Repeat("c", maxCommitMessageSize+1)
+
+	t.Run("error when message longer than max length", func(t *testing.T) {
+		assert.Error(t, c.check(Connection))
 	})
 }


### PR DESCRIPTION
100 was a catch all max string length intended for usernames and
aliases. Commit messages deserve to be longer. I thought about
enforcing this in the client as well, but decided against it.

This was the unknown bug that I referenced in the last commit.