### PR TITLE
Remove password for CLI settings and email to signup form

### DIFF
--- a/db/user_record.go
+++ b/db/user_record.go
@@ -220,7 +220,7 @@ WHERE username = ?`, passwordHash, username)
 }
 
 // CreateUser inserts a new user into the users table.
-func CreateUser(e Executor, username, password string) (*UserRecord, error) {
+func CreateUser(e Executor, username, email, password string) (*UserRecord, error) {
 	passwordHash, err := hashPassword(password)
 	if err != nil {
 		return nil, err
@@ -233,6 +233,7 @@ func CreateUser(e Executor, username, password string) (*UserRecord, error) {
 
 	u := &UserRecord{
 		Username:     username,
+		Email:        email,
 		PasswordHash: passwordHash,
 		CLIToken:     cliToken,
 	}

--- a/db/user_record_test.go
+++ b/db/user_record_test.go
@@ -23,10 +23,10 @@ func TestCreateUser(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		_, err := CreateUser(Connection, "user1", testPassword)
+		_, err := CreateUser(Connection, "user1", "", testPassword)
 		assert.NoError(t, err)
 
-		_, err = CreateUser(Connection, "user2", testPassword)
+		_, err = CreateUser(Connection, "user2", "test@example.com", testPassword)
 		assert.NoError(t, err)
 	})
 }

--- a/local/integration_test.go
+++ b/local/integration_test.go
@@ -40,7 +40,7 @@ func TestDotfilehubIntegration(t *testing.T) {
 		}
 	}()
 
-	user, err := db.CreateUser(db.Connection, dotfilehubUsername, dotfilehubPassword)
+	user, err := db.CreateUser(db.Connection, dotfilehubUsername, "", dotfilehubPassword)
 	failIf(t, err)
 
 	client := dotfileclient.New("http://"+dotfilehubAddr, dotfilehubUsername, user.CLIToken)

--- a/server/auth.go
+++ b/server/auth.go
@@ -110,6 +110,7 @@ func login(w http.ResponseWriter, r *http.Request, p *Page, secure bool) (done b
 func handleSignup(secure bool) pageBuilder {
 	return func(w http.ResponseWriter, r *http.Request, p *Page) (done bool) {
 		username := r.Form.Get("username")
+		email := r.Form.Get("email")
 		password := r.Form.Get("password")
 		confirm := r.Form.Get("confirm")
 
@@ -117,7 +118,7 @@ func handleSignup(secure bool) pageBuilder {
 			return p.setError(w, usererror.Invalid("Passwords do not match."))
 		}
 
-		_, err := db.CreateUser(db.Connection, username, password)
+		_, err := db.CreateUser(db.Connection, username, email, password)
 		if err != nil {
 			return p.setError(w, err)
 		}

--- a/server/helpers_test.go
+++ b/server/helpers_test.go
@@ -40,11 +40,16 @@ func setupTestRouter(t *testing.T, handler http.HandlerFunc) *mux.Router {
 }
 
 func setupTestPage(t *testing.T) (http.ResponseWriter, *http.Request, *Page) {
+	if err := loadTemplates(); err != nil {
+		t.Fatalf("loading templates: %v", err)
+	}
+
 	p := new(Page)
 	u := createTestUser(t)
 	p.Session = &db.UserSession{
 		UserID:   u.ID,
 		Username: u.Username,
+		CLIToken: u.CLIToken,
 	}
 	p.Vars = make(map[string]string)
 	p.Data = make(map[string]interface{})
@@ -93,7 +98,7 @@ func assertInternalError(t *testing.T, router *mux.Router, route string, method 
 }
 
 func createTestUser(t *testing.T) *db.UserRecord {
-	u, err := db.CreateUser(db.Connection, testUsername, testPassword)
+	u, err := db.CreateUser(db.Connection, testUsername, testEmail, testPassword)
 	if err != nil {
 		t.Fatalf("creating test user: %s", err)
 	}

--- a/server/html/terms.html
+++ b/server/html/terms.html
@@ -7,13 +7,12 @@
     </a>.
   </p>
   <p>
-    You are responsible for all content that you post on this website
-    - https://dotfilehub.com. Any content that is illegal,
-    copyrighted, or unsavory may be removed by an administrator
-    without notice. All content that is posted on this website can be
-    downloaded and reused by others. Do not post anything that has
-    sensitive data. Data may be kept after its deleted in database
-    backups or in web archiving services.
+    You are responsible for all content that you post on this
+    website. Any content that is illegal, copyrighted, or unsavory may
+    be removed by an administrator without notice. All content that is
+    posted on this website can be downloaded and reused by others. Do
+    not post anything that has sensitive data. Data may be kept after
+    it's deleted in database backups or in web archiving services.
   </p>
   <p>
     Admininstrators reserve the right to block access or terminate

--- a/server/templates/auth/signup.tmpl
+++ b/server/templates/auth/signup.tmpl
@@ -1,13 +1,16 @@
 <main>
     <h1>{{ .Title }}</h1>
-    <p>Usernames must be alphanumeric and passwords must be at least 8 characters.</p>
-    <p>By signing up you agree to the <a href="/terms"> terms.</a></p>
+    <p>Username must be alphanumeric and password must be at least 8 characters.</p>
+    <p>Email is optional; it's never shared and is only used for account recovery.</p>
+    <p>By signing up you agree to the <a href="/terms">terms</a>.</p>
     <form method="post">
-        <label for="username">Username</label>
+        <label for="username">Username:</label>
         <input id="username" name="username" type="text" required="required"/>
-        <label for="password">Password</label>
+        <label for="email">Email:</label>
+        <input id="email" name="email" type="email"/>
+        <label for="password">Password:</label>
         <input id="password" name="password" type="password" required="required"/>
-        <label for="confirm">Confirm</label>
+        <label for="confirm">Confirm Password:</label>
         <input id="confirm" name="confirm" type="password" required="required"/>
         <button>Submit</button>
     </form>

--- a/server/templates/user/cli.tmpl
+++ b/server/templates/user/cli.tmpl
@@ -1,18 +1,10 @@
 <main>
   {{- template "settings_header" . }}
-  {{- if not .Data.authenticated -}}
-  <form method="post">
-    <label for="password">Password:</label>
-    <input id="password" name="password" type="password" required="required"/>
-    <button>Submit</button>
-  </form>
-  {{ else }}
-    <pre><code>dotfile config username {{ .Username }}</code></pre>
-    <pre><code>dotfile config token {{ .CLIToken }}</code></pre>
-    <pre><code>dotfile config remote {{ .Data.remote }}</code></pre>
+  <pre><code>dotfile config username {{ .Username }}</code></pre>
+  <pre><code>dotfile config token {{ .CLIToken }}</code></pre>
+  <pre><code>dotfile config remote {{ .Data.remote }}</code></pre>
   <form method="post" class="inline">
-    <input type="hidden" name="token" value="{{ .Data.token }}"/>
+    <input type="hidden" name="token" value="{{ .CLIToken }}"/>
     <button class="success">Rotate Token</button>
   </form>
-  {{ end -}}
 </main>

--- a/server/user_test.go
+++ b/server/user_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 )
@@ -15,4 +16,72 @@ func TestUserHandler(t *testing.T) {
 		_ = createTestUser(t)
 		assertOK(t, router, testFilePath, http.MethodGet)
 	})
+}
+
+func TestReloadSession(t *testing.T) {
+	setupTestDB(t)
+
+	t.Run("ok on GET", func(t *testing.T) {
+		defer clearTestUser(t)
+		w, r, p := setupTestPage(t)
+		r.Method = "GET"
+
+		reloadSession(w, r, p)
+		assert.Empty(t, p.ErrorMessage)
+	})
+
+	t.Run("ok on POST", func(t *testing.T) {
+		w, r, p := setupTestPage(t)
+		r.Method = "POST"
+
+		reloadSession(w, r, p)
+		assert.Empty(t, p.ErrorMessage)
+	})
+}
+
+func TestLoadThemes(t *testing.T) {
+	setupTestDB(t)
+
+	w, r, p := setupTestPage(t)
+	loadThemes(w, r, p)
+	assert.Empty(t, p.ErrorMessage)
+}
+
+func TestHandleTimezone(t *testing.T) {
+	setupTestDB(t)
+
+	t.Run("ok", func(t *testing.T) {
+		w, r, p := setupTestPage(t)
+		handleTimezone(w, r, p)
+		assert.Empty(t, p.ErrorMessage)
+	})
+}
+
+func TestHandleTheme(t *testing.T) {
+	setupTestDB(t)
+
+	t.Run("ok", func(t *testing.T) {
+		w, r, p := setupTestPage(t)
+		handleTheme(w, r, p)
+		assert.Empty(t, p.ErrorMessage)
+	})
+}
+
+func TestHandleTokenForm(t *testing.T) {
+	setupTestDB(t)
+
+	t.Run("error on token mismatch", func(t *testing.T) {
+		defer clearTestUser(t)
+		w, r, p := setupTestPage(t)
+		handleTokenForm(w, r, p)
+		assert.NotEmpty(t, p.ErrorMessage)
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		w, r, p := setupTestPage(t)
+		r.Form.Set("token", p.CLIToken())
+		handleTokenForm(w, r, p)
+		assert.Empty(t, p.ErrorMessage)
+	})
+
 }


### PR DESCRIPTION
Previously users had to enter a password before being able to see the
CLI token. While this seemed like a good security feature, I realized
that it was mostly redudant because updating the email isn't password
protected, and that gives access to the account through account recovery.

This should decrease friction for first time users getting setup.