### PR TITLE
Host with Fly.IO

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# flyctl launch added from .gitignore
+# Test binary, build with `go test -c`
+.git/
+**/*.test
+**/todo.txt
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+**/*.out
+
+**/coverage.txt
+
+# Emacs temp files
+**/*~
+**/\#*\#
+
+# Vim temp files
+**/*.swp
+
+**/testdata
+**/*.json
+
+# Generated html files
+**/server/html/README.html
+**/server/html/acknowledgments.html
+**/server/html/cli.html
+**/server/html/web.html
+
+# flyctl launch added from bin/.gitignore
+# Ignore everything in this directory
+bin/**/*
+
+# Except this file
+!bin/**/.gitignore
+fly.toml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # flyctl launch added from .gitignore
 # Test binary, build with `go test -c`
+*.db
 .git/
 **/*.test
 **/todo.txt

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ todo.txt
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+*.db
+
 coverage.txt
 
 # Emacs temp files

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-go:
-  - 1.13.x
-
-script:
-  - env GO111MODULE=on make ci_test
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# fly.io uses Ubuntu/Debian instead of Alpine to avoid DNS resolution issues in production.
+
+ARG BUILDER_IMAGE="golang:1.18.10-buster"
+ARG RUNNER_IMAGE="debian:bullseye-20220801-slim"
+
+FROM ${BUILDER_IMAGE} as builder
+
+# prepare build dir
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+COPY . .
+RUN make dotfilehub
+
+# start a new build stage so that the final image will only contain the compiled binary
+FROM ${RUNNER_IMAGE}
+
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales \
+  && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+WORKDIR "/app/bin"
+RUN chown nobody /app
+
+COPY --from=builder --chown=nobody:root /app/bin/dotfilehub .
+
+USER nobody
+
+CMD [\
+    "/app/bin/dotfilehub",\
+    "-addr=:8080",\
+    "-db=/data/dotfilehub.db",\
+    "-host=dotfilehub.com",\
+    "-secure",\
+    "-proxyheaders"\
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN make dotfilehub
 # start a new build stage so that the final image will only contain the compiled binary
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales \
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale
@@ -36,6 +36,7 @@ CMD [\
     "/app/bin/dotfilehub",\
     "-addr=:8080",\
     "-db=/data/dotfilehub.db",\
+    "-smtp-config-path=/data/smtp.json",\
     "-host=dotfilehub.com",\
     "-secure",\
     "-proxyheaders"\

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dotfilehub: htmldocs
 dotfilehub_image:
 	docker build . --tag dotfilehub
 
-run_dotfilehub_image:
+run_dotfilehub_image: dotfilehub_image
 	docker container run -p=8080:8080 --mount type=bind,source=${HOME}/.dotfilehub.db,target=/data/dotfilehub.db dotfilehub
 
 deploy: test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CURRENT_DIR = $(shell pwd)
 GO_TEST_FLAGS := -v -cover -count=1 -race
 GO_TEST_TARGET := ./...
 
@@ -20,7 +21,10 @@ dotfilehub_image:
 	docker build . --tag dotfilehub
 
 run_dotfilehub_image: dotfilehub_image
-	docker container run -p=8080:8080 --mount type=bind,source=${HOME}/.dotfilehub.db,target=/data/dotfilehub.db dotfilehub
+	docker container run -p=8080:8080\
+		--mount type=bind,source=${HOME}/.dotfilehub.db,target=/data/dotfilehub.db\
+		--mount type=bind,source=$(CURRENT_DIR)/server/smtp.sample.json,target=/data/smtp.json\
+		dotfilehub
 
 deploy: test
 	fly deploy

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,8 @@
-GO_TEST_FLAGS := -v -cover -count=1
-GO_DEEP_TEST_FLAGS := $(GO_TEST_FLAGS) -race
-CI_GO_TEST_FLAGS := $(GO_DEEP_TEST_FLAGS) -coverprofile=coverage.txt -covermode=atomic
+GO_TEST_FLAGS := -v -cover -count=1 -race
 GO_TEST_TARGET := ./...
 
 test:
 	go test $(GO_TEST_FLAGS) $(GO_TEST_TARGET)
-
-deep_test:
-	go test $(GO_DEEP_TEST_FLAGS) $(GO_TEST_TARGET)
-
-ci_test:
-	go test $(CI_GO_TEST_FLAGS) $(GO_TEST_TARGET)
 
 dotfile:
 	go build -o bin/dotfile cmd/dotfile/main.go
@@ -30,7 +22,10 @@ dotfilehub_image:
 run_dotfilehub_image:
 	docker container run -p=8080:8080 --mount type=bind,source=${HOME}/.dotfilehub.db,target=/data/dotfilehub.db dotfilehub
 
+deploy: test
+	fly deploy
+
 clean:
 	rm -rf bin/*
 
-.PHONY: test deep_test ci_test dotfile htmlgen htmldocs dotfilehub dotfilehub_container run_dotfilehub_container
+.PHONY: test dotfile htmlgen htmldocs dotfilehub dotfilehub_image run_dotfilehub_image deploy clean

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,13 @@ htmldocs: htmlgen
 dotfilehub: htmldocs
 	go build -o bin/dotfilehub cmd/dotfilehub/main.go
 
+dotfilehub_image:
+	docker build . --tag dotfilehub
+
+run_dotfilehub_image:
+	docker container run -p=8080:8080 --mount type=bind,source=${HOME}/.dotfilehub.db,target=/data/dotfilehub.db dotfilehub
+
 clean:
 	rm -rf bin/*
 
-.PHONY: dotfile dotfilehub
+.PHONY: test deep_test ci_test dotfile htmlgen htmldocs dotfilehub dotfilehub_container run_dotfilehub_container

--- a/docs/web.org
+++ b/docs/web.org
@@ -150,3 +150,9 @@ path to a JSON file. The file must contain the following keys:
 }
 #+END_SRC
 The client will use PLAIN authentication.
+
+** Example
+
+dotfilehub.com is currently hosted with [[https://fly.io][fly.io]], for an example
+=Dockerfile= and =fly.toml=, see the top level of
+https://github.com/knoebber/dotfile

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,39 @@
+# fly.toml file generated for dotfilehub on 2023-01-18T18:20:13-08:00
+
+app = "dotfilehub"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 8080
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"
+
+[mounts]
+  source="dotfilehub_data"
+  destination="/data"


### PR DESCRIPTION
Currently live at https://dotfilehub.fly.dev/

Still need to move over the prod db and configure the emailer. 

@dooleydevin - once I merge this that means https://dotfilehub.com is fully migrated, which means you'll be able to shutdown the current VM. Thx for hosting dotfilehub for the last 2 years!
